### PR TITLE
Fixed PID autotuning

### DIFF
--- a/espressiot/tuning.ino
+++ b/espressiot/tuning.ino
@@ -7,6 +7,7 @@
 //
 
 double aTuneStep = 100.0, aTuneThres = 0.2;
+double maxUpperT = 0, minLowerT = 0;
 double AvgUpperT = 0, AvgLowerT = 0;
 int UpperCnt = 0, LowerCnt = 0;
 int tune_count = 0;
@@ -20,6 +21,7 @@ void tuning_on() {
   tune_count = 0;
   UpperCnt = 0; LowerCnt = 0;
   AvgUpperT = 0; AvgLowerT = 0;
+  maxUpperT = 0; minLowerT = 0;
   ESPPID.SetMode(MANUAL);
   tuning = true;
 }
@@ -49,18 +51,38 @@ void tuning_loop() {
       if (tune_count == 0) tune_start = time_now;
       tune_time = time_now;
       tune_count++;
-      AvgLowerT += gInputTemp;
-      LowerCnt++;
+      //AvgLowerT += gInputTemp;
+      //LowerCnt++;
     }
+    if (minLowerT > gInputTemp || minLowerT == 0) minLowerT = gInputTemp;
     gOutputPwr = aTuneStep;
     setHeatPowerPercentage(aTuneStep);
   }
   else if (gInputTemp > (gTargetTemp + aTuneThres)) { // above upper threshold -> power off
-    if (gOutputPwr == aTuneStep) { // just crossed upper threshold
-      AvgUpperT += gInputTemp;
-      UpperCnt++;
-    }
+    //if (gOutputPwr == aTuneStep) { // just crossed upper threshold
+      //AvgUpperT += gInputTemp;
+      //UpperCnt++;
+    //}
+    if (maxUpperT < gInputTemp) maxUpperT = gInputTemp;
     gOutputPwr = 0;
     setHeatPowerPercentage(0);
+  }
+
+  // store min / max
+  if ((gInputTemp > (gTargetTemp - (aTuneThres / 2))) && (gInputTemp < (gTargetTemp + (aTuneThres / 2)))) {
+    if (maxUpperT != 0) {
+      Serial.println("Adding new upper T");
+      Serial.println(maxUpperT);
+      AvgUpperT += maxUpperT;
+      UpperCnt ++;
+      maxUpperT = 0;
+    }
+    if (minLowerT != 0) {
+      Serial.println("Adding new lower T");
+      Serial.println(minLowerT);
+      AvgLowerT += minLowerT;
+      LowerCnt ++;
+      minLowerT = 0;
+    }
   }
 }


### PR DESCRIPTION
I belive there is an error in PID autotuning which should be fixed with this PR.

I am definitely not an expert on this topic (just started looking into this) but according to the Blogpost referred to in this project (http://brettbeauregard.com/blog/2012/01/arduino-pid-autotune-library/) the peaks should be the most significant values.

What is the issue?
The autotuning will choose and store the "min" and "max" values as soon as the threshold is passed and therefore uses values that are extremely close to the threshold.

What changed?
Now, the autotuning will store the most significant min/max value in a separate variable and "commit" to it when the temperature is "swinging back" over 1/2 of the threshold. This should ensure that the values are the actual peak values that occurred during tuning.

Thank you for your efforts!